### PR TITLE
PL allow DEs to be cleared via fuelSDK gem

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 FuelSDK-Ruby
 ============
 
-2014-02-01: Version 0.1.13
+2017-02-01: Version 0.1.13
 ```
   Add support for clearing data extensions
 ```

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,25 @@
 FuelSDK-Ruby
 ============
 
+2014-02-01: Version 0.1.13
+```
+  Add support for clearing data extensions
+```
+
+2017-01-24: Version 0.1.12
+```
+  Add support for import definitions and automation objects
+```
+2016-10-03: Version 0.1.11
+```
+  Add support for QueryDefinition and EmailSendDefinition
+```
+
+2015-05-02: Version 0.1.10
+```
+  Add activesupport to gemspec
+```
+
 2014-06-23: Version 0.1.9
 ```
   Fix ContinueRequest

--- a/lib/fuelsdk/objects.rb
+++ b/lib/fuelsdk/objects.rb
@@ -149,6 +149,7 @@ module FuelSDK
   class DataExtension < Objects::Base
     include Objects::Soap::Read
     include Objects::Soap::CUD
+    include Objects::Soap::Perform
     attr_accessor :fields
     alias columns= fields= # backward compatibility
 

--- a/lib/fuelsdk/soap.rb
+++ b/lib/fuelsdk/soap.rb
@@ -314,13 +314,9 @@ module FuelSDK
       }
     end
 
-    def soap_perform object_type, properties, action
-      message = create_action_message 'Definitions', object_type, properties, action
-      soap_request :perform, message
-    end
-
     def soap_perform object_type, properties, options = {}
-      message = create_action_message 'Definitions', object_type, properties, 'Start'
+      action = options[:action] || 'Start'
+      message = create_action_message 'Definitions', object_type, properties, action
 
       response = soap_request :perform, message
       if options[:synchronous]

--- a/lib/fuelsdk/version.rb
+++ b/lib/fuelsdk/version.rb
@@ -1,3 +1,3 @@
 module FuelSDK
-  VERSION = "0.1.12"
+  VERSION = "0.1.13"
 end


### PR DESCRIPTION
This is so we can automate CD email cleanup after each send. 

Also updated the changelog cause why not.