### PR TITLE
PL - add perform method to SOAP DE objects

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
 FuelSDK-Ruby
 ============
 
+2017-02-03: Version 0.1.15
+```
+  Hotfix for clearing data extensions
+```
+
 2017-02-01: Version 0.1.14
 ```
   Add better error handling for activity polling

--- a/lib/fuelsdk/objects.rb
+++ b/lib/fuelsdk/objects.rb
@@ -158,6 +158,10 @@ module FuelSDK
       super
     end
 
+    def perform options
+      super
+    end
+
     def patch
       munge_fields self.properties
       super

--- a/lib/fuelsdk/version.rb
+++ b/lib/fuelsdk/version.rb
@@ -1,3 +1,3 @@
 module FuelSDK
-  VERSION = "0.1.14"
+  VERSION = "0.1.15"
 end


### PR DESCRIPTION
Last release I made for this gem was missing the perform method which resulting in requests to clear DEs bombing out

I can update the gem version for sfmc_populater this time if you'd like, @mdimas 

