### PR TITLE
auto auth refresh

### DIFF
--- a/lib/fuelsdk/soap.rb
+++ b/lib/fuelsdk/soap.rb
@@ -437,6 +437,10 @@ module FuelSDK
         retried = false
         begin
           rsp = soap_client.call(action, :message => message)
+          if rsp.to_s =~ /FailedAuthentication/
+            refresh!
+            raise "FailedAuthentication"
+          end
         rescue
           raise if retried
           retried = true

--- a/lib/fuelsdk/version.rb
+++ b/lib/fuelsdk/version.rb
@@ -1,3 +1,3 @@
 module FuelSDK
-  VERSION = "0.1.14"
+  VERSION = "0.1.15"
 end


### PR DESCRIPTION
The auth token will time out (even if in use) after about 18 minutes. This means that the content sync starts failing if we’re syncing all our emails. It also means that the query polling code will fail if the query runs for longer than 18 minutes

@davidmarotto @leebs778 @willbarrett 